### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare module 'replit-graphql' {
 		raw?: boolean;
 	}
 
-	export function query(query: string, config?: GraphQLConfig): Promise<object>;
+	export function query(query: string, config?: GraphQLConfig): Promise<Record<string, any>>;
 
 	export function subscribe(subscription: string, config?: GraphQLConfig): EventEmitter;
 


### PR DESCRIPTION
Fixed return value for the query function. It should return a `Record`, not an `object` type. It'll prevent errors like this ![replit-graphql ts error example](https://media.pikachub2005.repl.co/replit-graphql-error.png)